### PR TITLE
first commit, fix loading raw files for apply_ica

### DIFF
--- a/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
@@ -92,15 +92,36 @@ def get_input_fnames_apply_ica_raw(
     run: str,
     task: str | None,
 ) -> InFilesT:
-    in_files = _get_run_rest_noise_path(
-        cfg=cfg,
+    # this loads the raw file for filtered data; undesired if we did eyelink_sync or any other step inbetween
+    # in_files = _get_run_rest_noise_path(
+    #     cfg=cfg,
+    #     subject=subject,
+    #     session=session,
+    #     run=run,
+    #     task=task,
+    #     kind="filt",
+    #     mf_reference_run=cfg.mf_reference_run,
+    # )
+    # do this instead
+    bids_basename = BIDSPath(
         subject=subject,
         session=session,
-        run=run,
-        task=task,
-        kind="filt",
-        mf_reference_run=cfg.mf_reference_run,
+        task=cfg.task,
+        acquisition=cfg.acq,
+        recording=cfg.rec,
+        space=cfg.space,
+        datatype=cfg.datatype,
+        root=cfg.deriv_root,
+        check=False,
+        extension=".fif",
     )
+    in_files = dict()
+    for run in cfg.runs:
+        key = f"raw_run-{run}"
+        in_files[key] = bids_basename.copy().update(
+            run=run, processing=cfg.processing, suffix="raw"
+        )
+        _update_for_splits(in_files, key, single=True)
     assert len(in_files)
     in_files.update(_ica_paths(cfg=cfg, subject=subject, session=session))
     return in_files

--- a/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
@@ -92,17 +92,6 @@ def get_input_fnames_apply_ica_raw(
     run: str,
     task: str | None,
 ) -> InFilesT:
-    # this loads the raw file for filtered data; undesired if we did eyelink_sync or any other step inbetween
-    # in_files = _get_run_rest_noise_path(
-    #     cfg=cfg,
-    #     subject=subject,
-    #     session=session,
-    #     run=run,
-    #     task=task,
-    #     kind="filt",
-    #     mf_reference_run=cfg.mf_reference_run,
-    # )
-    # do this instead
     bids_basename = BIDSPath(
         subject=subject,
         session=session,


### PR DESCRIPTION
apply_ica grabs the raw data from the filtered step. this is not a problem if there are no intervening steps, as is the case upstream, but it is a problem if eyelink_sync has been performed in between.

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
