### PR TITLE
Calib fix

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1216,6 +1216,11 @@ When displaying HEOG-ET cross-correlation, constrict plotting to sync_plot_samps
     ```
 """
 
+sync_calibration_string: str | None = ".* Recalibration (start|end) \\| (.*)"
+"""
+Regular expression used for searching for calibration events
+"""
+
 # ### SSP, ICA, and artifact regression
 
 regress_artifact: dict[str, Any] | None = None


### PR DESCRIPTION
This makes mark_calibration_as_bad robust to duplicate calibration start/stop triggers, and also makes the regular expression agnostic to the ID of the trigger, i.e. the ID can be any string now, as opposed to any number