### PR TITLE
Set specifications for eye-tracking file name handling

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1150,6 +1150,28 @@ remove_blink_saccades: bool = True
 Currently not implemented
 """
 
+et_has_run: bool = False
+"""
+Specify whether `run` is included in the eye-tracking data file name.
+
+???+ example "Example"
+    ``` python
+    et_has_run = False  # Case with only one run and run is omitted in the file name.
+    et_has_run = True  # Case with multiple runs. Run specification from EEG data is used.
+    ```
+"""
+
+et_has_task: bool = False
+"""
+Specify whether `task` is included in the eye-tracking data file name.
+
+???+ example "Example"
+    ``` python
+    et_has_task = False  # Case with only one task and task is omitted in the file name.
+    et_has_task = True  # Case with multiple tasks. Task specification from EEG data is used.
+    ```
+"""
+
 sync_eventtype_regex: str = ""
 """
 Regular expression which will be used to select events in the EEG file for synchronisation 

--- a/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
@@ -67,6 +67,13 @@ def get_input_fnames_sync_eyelink(
     subject: str,
     session: str | None,
 ) -> dict:
+    
+    # Get from config file whether `task` is specified in the et file name
+    if cfg.et_has_task == True:
+        et_task = cfg.task
+    else:
+        et_task = None
+
     bids_basename = BIDSPath(
         subject=subject,
         session=session,
@@ -83,7 +90,7 @@ def get_input_fnames_sync_eyelink(
     et_bids_basename = BIDSPath(
         subject=subject,
         session=session,
-        task=cfg.task,
+        task=et_task,
         acquisition=cfg.acq,
         recording=cfg.rec,
         datatype="beh",
@@ -93,11 +100,10 @@ def get_input_fnames_sync_eyelink(
         extension=".asc",
     )
 
-
     et_edf_bids_basename = BIDSPath(
         subject=subject,
         session=session,
-        task=cfg.task,
+        task=et_task,
         acquisition=cfg.acq,
         recording=cfg.rec,
         datatype="beh",
@@ -117,16 +123,20 @@ def get_input_fnames_sync_eyelink(
 
 
         key = f"et_run-{run}"
-        in_files[key] = et_bids_basename.copy().update(
-            run=run
-        )
-        _update_for_splits(in_files, key, single=True) # TODO: Find out if we need to add this or not
+        in_files[key] = et_bids_basename.copy()
+
+        if cfg.et_has_run:
+            in_files[key].update(run=run)
+
+        # _update_for_splits(in_files, key, single=True) # TODO: Find out if we need to add this or not
 
         key = f"et_edf_run-{run}"
-        in_files[key] = et_edf_bids_basename.copy().update(
-            run=run
-        )
-        _update_for_splits(in_files, key, single=True) # TODO: Find out if we need to add this or not
+        in_files[key] = et_edf_bids_basename.copy()
+
+        if cfg.et_has_run:
+            in_files[key].update(run=run)
+
+        # _update_for_splits(in_files, key, single=True) # TODO: Find out if we need to add this or not
     
     return in_files
 
@@ -341,6 +351,8 @@ def get_config(
     cfg = SimpleNamespace(
         runs=get_runs(config=config, subject=subject),
         remove_blink_saccades   = config.remove_blink_saccades,
+        et_has_run = config.et_has_run,
+        et_has_task = config.et_has_task,
         sync_eventtype_regex    = config.sync_eventtype_regex,
         sync_eventtype_regex_et = config.sync_eventtype_regex_et,
         sync_heog_ch = config.sync_heog_ch,


### PR DESCRIPTION
# Changes:
- Before the eye-tracking files needed to have `task` and `run` specified. I have now introduced two variables in the config file `et_has_run` and `et_has_task`, that indicate whether the eye-tracking file names have task and run specified or not.

  If they are set to `False`, it is assumed that the file name does not have task or run. If they are set to `True` , `task` and `run` are taken from the EEG data.

- I commented out the `_update_for_splits` function calls for the eye-tracking data paths. We still need to find out whether we need them or not.

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
