### PR TITLE
Extract and synchronise ET events

### DIFF
--- a/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
@@ -175,6 +175,7 @@ def sync_eyelink(
     out_files["eyelink_eeg"] = bids_basename.copy().update(processing="eyelink", suffix="raw")
     del bids_basename
 
+    # Ideally, this would be done in one of the previous steps where all folders are created (in `_01_init_derivatives_dir.py`). 
     logger.info(**gen_log_kwargs(message=f"Create `beh` folder for eye-tracking events."))
     out_dir_beh = cfg.deriv_root / f"sub-{subject}"
     if session is not None:
@@ -298,7 +299,7 @@ def sync_eyelink(
         # Synchronize time stamps of ET events
         et_combined_df["onset"] = (et_combined_df["onset"] * first_ord + zero_ord)
         et_combined_df["end_time"] = (et_combined_df["end_time"] * first_ord + zero_ord)
-        # TODO: Do we also need to "synchronize"/adapt the duration column?
+        # TODO: To be super correct, we would need to recalculate duration column as well - but typically the slope is so close to "1" that this would typically result in <1ms differences
 
         msg = f"Saving synced eye-tracking events to disk."
         logger.info(**gen_log_kwargs(message=msg))

--- a/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
@@ -234,7 +234,7 @@ def sync_eyelink(
         # Also add ET annotations to EEG
         # first mark et sync event descriptions so we can differentiate them later
         # TODO: For now all ET events will be marked with ET and added to the EEG annotations, maybe later filter for certain events only
-        raw_et.annotations.description = map(lambda desc: "ET_" + desc, raw_et.annotations.description)
+        raw_et.annotations.description = np.array(list(map(lambda desc: "ET_" + desc, raw_et.annotations.description)))
         raw.set_annotations(mne.annotations._combine_annotations(raw.annotations,
                                                                  raw_et.annotations,
                                                                  0,


### PR DESCRIPTION
# Changes & implementation decisions
- Name eye-tracking events with suffix `et_events` for now
- Create `beh` folder in the `sync_eyelink` function
- Set `find_overlaps` parameter of `read_raw_eyelink` to `False` until we learn more about combining binocular data
- Remove appending eye-tracking `_raw_extras` to the EEG ones because we found out it does not work this way
- Mark all eye-tracking events in the annotations with `ET` and add them to the EEG annotations (instead of only marking the synchronisation events)
	- Disadvantages: We have duplicate experimental events, we have eye movement events (e.g. saccades) in the annotations as well as in the et_events.tsv
	- Advantages: It's possible to check the synchronisation using the onsets from the annotations, we don't lose events like `BAD_ACQ_SKIP` and don't have to put extra (custom) effort in the pipeline to extract them (but shift that to a later preprocessing step)
- For the eye-tracking events, combine saccades, fixations and blinks data frames from `_raw_extras`
- Synchronize `onset` and `end_time` of the eye-tracking events by recalculating the regression coefficients from the EEG+ET synchronisation

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
